### PR TITLE
Make Tweet datetime timezone aware

### DIFF
--- a/twitter_tag/templatetags/twitter_tag.py
+++ b/twitter_tag/templatetags/twitter_tag.py
@@ -6,6 +6,7 @@ import logging
 from django import template
 from django.conf import settings
 from django.core.cache import cache
+from django.utils.tzinfo import FixedOffset
 
 from twitter import Twitter, OAuth, TwitterError
 from classytags.core import Tag, Options
@@ -37,7 +38,7 @@ class BaseTwitterTag(Tag):
         """ Apply the local presentation logic to the fetched data."""
         tweet = urlize_tweet(expand_tweet_urls(tweet))
         # parses created_at "Wed Aug 27 13:08:45 +0000 2008"
-        tweet['datetime'] = datetime.strptime(tweet['created_at'], '%a %b %d %H:%M:%S +0000 %Y')
+        tweet['datetime'] = datetime.strptime(tweet['created_at'], '%a %b %d %H:%M:%S +0000 %Y').replace(tzinfo=FixedOffset(0))
         return tweet
 
     def render_tag(self, context, **kwargs):

--- a/twitter_tag/utils.py
+++ b/twitter_tag/utils.py
@@ -24,7 +24,7 @@ def get_search_cache_key(prefix, *args):
     return key
 
 
-TWITTER_HASHTAG_URL = '<a href="https://twitter.com/search?q=#%s">%s</a>'
+TWITTER_HASHTAG_URL = '<a href="https://twitter.com/search?q=#%s">#%s</a>'
 TWITTER_USERNAME_URL = '<a href="https://twitter.com/%s">@%s</a>'
 
 


### PR DESCRIPTION
Sets the tweet datetime's timezone to UTC, so it will play better with local times.
