### PR TITLE
Hash in hashtag link needs to be url encoded

### DIFF
--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -204,8 +204,8 @@ class SearchTag(TwitterTag):
             json_mocks='python3.json',
         )
         tweet_html = context['tweets'][0]['html']
-        expect(tweet_html).should.contain('<a href="https://twitter.com/search?q=#python">#python')
-        expect(tweet_html).should.contain('<a href="https://twitter.com/search?q=#CouchDB">#CouchDB')
+        expect(tweet_html).should.contain('<a href="https://twitter.com/search?q=%23python">#python')
+        expect(tweet_html).should.contain('<a href="https://twitter.com/search?q=%23CouchDB">#CouchDB')
 
     @nottest # https://github.com/gabrielfalcao/HTTPretty/issues/36')
     @httprettified

--- a/twitter_tag/utils.py
+++ b/twitter_tag/utils.py
@@ -24,7 +24,7 @@ def get_search_cache_key(prefix, *args):
     return key
 
 
-TWITTER_HASHTAG_URL = '<a href="https://twitter.com/search?q=#%s">#%s</a>'
+TWITTER_HASHTAG_URL = '<a href="https://twitter.com/search?q=%%23%s">#%s</a>'
 TWITTER_USERNAME_URL = '<a href="https://twitter.com/%s">@%s</a>'
 
 


### PR DESCRIPTION
The url created for hashtags needs to have the `#` converted to an html entity for proper linking to a twitter search.
