### PR TITLE
added fallback search argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,11 +124,11 @@ Search api arguments are supported via key=value pairs::
 
     {% search_tweets for "python 3" as tweets lang='eu' result_type='popular' %}
 
-Add a fallback search query if the supplied hashtag doesn't return any results:
+Add a fallback search query if the supplied hashtag doesn't return any results::
 
     {% search_tweets for "SuperObscureHashTag" as tweets fallback "Art" limit 20 %}
 
-Add an exclusion query for your search and a fallback search query if the supplied hashtag doesn't return any results:
+Add an exclusion query for your search and a fallback search query if the supplied hashtag doesn't return any results::
 
     {% search_tweets for "outerspace" as tweets exclude " -#nasa" fallback "space" limit 20 %}
 

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,10 @@ Search api arguments are supported via key=value pairs::
 
     {% search_tweets for "python 3" as tweets lang='eu' result_type='popular' %}
 
+Add a fallback search query if the supplied hashtag doesn't return any results::
+
+    {% search_tweets for "SuperObscureHashTag" as tweets limit 20 fallback "Art" %}
+
 Relevant `API docs for search`_.
 
 .. _API docs for search: https://dev.twitter.com/docs/api/1.1/get/search/tweets

--- a/README.rst
+++ b/README.rst
@@ -124,9 +124,13 @@ Search api arguments are supported via key=value pairs::
 
     {% search_tweets for "python 3" as tweets lang='eu' result_type='popular' %}
 
-Add a fallback search query if the supplied hashtag doesn't return any results::
+Add a fallback search query if the supplied hashtag doesn't return any results:
 
-    {% search_tweets for "SuperObscureHashTag" as tweets limit 20 fallback "Art" %}
+    {% search_tweets for "SuperObscureHashTag" as tweets fallback "Art" limit 20 %}
+
+Add an exclusion query for your search and a fallback search query if the supplied hashtag doesn't return any results:
+
+    {% search_tweets for "outerspace" as tweets exclude " -#nasa" fallback "space" limit 20 %}
 
 Relevant `API docs for search`_.
 

--- a/twitter_tag/templatetags/twitter_tag.py
+++ b/twitter_tag/templatetags/twitter_tag.py
@@ -56,8 +56,6 @@ class BaseTwitterTag(Tag):
                                          settings.TWITTER_CONSUMER_SECRET))
             json = self.get_json(twitter, **self.get_api_call_params(**kwargs))
 
-            print len(json)
-
             if len(json) <= 0:
                 json = self.get_json(twitter, **self.get_api_fallback_call_params(**kwargs))
 

--- a/twitter_tag/templatetags/twitter_tag.py
+++ b/twitter_tag/templatetags/twitter_tag.py
@@ -122,8 +122,9 @@ class SearchTag(BaseTwitterTag):
         'for', Argument('q'),
         'as', Argument('asvar', resolve=False),
         MultiKeywordArgument('options', required=False),
-        'limit', Argument('limit', required=False),
+        'exclude', Argument('exclude', required=False),
         'fallback', Argument('fallback', required=False),
+        'limit', Argument('limit', required=False),
     )
 
     def get_cache_key(self, kwargs_dict):

--- a/twitter_tag/templatetags/twitter_tag.py
+++ b/twitter_tag/templatetags/twitter_tag.py
@@ -55,6 +55,12 @@ class BaseTwitterTag(Tag):
                                          settings.TWITTER_CONSUMER_KEY,
                                          settings.TWITTER_CONSUMER_SECRET))
             json = self.get_json(twitter, **self.get_api_call_params(**kwargs))
+
+            print len(json)
+
+            if len(json) <= 0:
+                json = self.get_json(twitter, **self.get_api_fallback_call_params(**kwargs))
+
         except (TwitterError, URLError, ValueError, http_client.HTTPException) as e:
             logging.getLogger(__name__).error(str(e))
             context[kwargs['asvar']] = cache.get(cache_key, [])
@@ -119,6 +125,7 @@ class SearchTag(BaseTwitterTag):
         'as', Argument('asvar', resolve=False),
         MultiKeywordArgument('options', required=False),
         'limit', Argument('limit', required=False),
+        'fallback', Argument('fallback', required=False),
     )
 
     def get_cache_key(self, kwargs_dict):
@@ -126,6 +133,11 @@ class SearchTag(BaseTwitterTag):
 
     def get_api_call_params(self, **kwargs):
         params = {'q': kwargs['q'].encode('utf-8')}
+        params.update(kwargs['options'])
+        return params
+
+    def get_api_fallback_call_params(self, **kwargs):
+        params = {'q': kwargs['fallback'].encode('utf-8')}
         params.update(kwargs['options'])
         return params
 


### PR DESCRIPTION
added a fallback search argument for when you need to make sure that there's content in the tweeter feed section of the page. If there's no specific tweets with a hashtag it will default to a more generic search perhaps.

Works with caching and all of that stuff too.
